### PR TITLE
Fix to a bug in the gulag code

### DIFF
--- a/src/commands/owner.rs
+++ b/src/commands/owner.rs
@@ -60,8 +60,7 @@ fn gulag(ctx: &mut Context, msg: &Message) -> CommandResult {
 
     if let Err(_) = _member.user.read().direct_message(&ctx,|m|
         m.content(format!("You will be released in {} minute(s)",time))) {
-        error!("Couldn't give gulag role");
-        return Err(CommandError(String::from("Couldn't parse stuff")))
+        error!("Couldn't send info dm");
     };
 
     thread::sleep(Duration::from_secs(time*60));


### PR DESCRIPTION
In the case that the bot failed to send a dm to a user it would just
quit. This would result in a user stuck in the gulag. Some causes for
this included the user in question blocking the bot or the user being a
bot as well and not being able to receive dms.